### PR TITLE
Enable override of Raven listen URL

### DIFF
--- a/docker/ravendb-nanoserver/run-raven.ps1
+++ b/docker/ravendb-nanoserver/run-raven.ps1
@@ -2,7 +2,9 @@ $ErrorActionPreference = 'Stop'
 
 $COMMAND=".\Raven.Server.exe"
 $hostname = & "hostname.exe"
-$env:RAVEN_ServerUrl = "http://$($hostname):8080"
+if ([string]::IsNullOrEmpty($env:RAVEN_SETTINGS) -eq $True) {
+    $env:RAVEN_ServerUrl = "http://$($hostname):8080"
+}
 
 if ([string]::IsNullOrEmpty($env:RAVEN_SETTINGS) -eq $False) {
     Set-Content -Path "settings.json" -Value "$env:RAVEN_SETTINGS"

--- a/docker/ravendb-ubuntu/run-raven.sh
+++ b/docker/ravendb-ubuntu/run-raven.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 COMMAND="./Raven.Server"
-export RAVEN_ServerUrl="http://$(hostname):8080"
+[ -z "$RAVEN_ServerUrl" ] && export RAVEN_ServerUrl="http://$(hostname):8080"
 
 if [ ! -z "$RAVEN_SETTINGS" ]; then
     echo "$RAVEN_SETTINGS" > settings.json


### PR DESCRIPTION
### Issue link

ravendb/ravendb#13254

### Additional description

Enable user's to change the IP/port Raven internally listens on.

### Type of change

- Optimization

### How risky is the change?

- Low 

### Backward compatibility

- Ensured. Please explain how has it been implemented? If not set, default still applies.

### Is it platform specific issue?

- Yes. Docker

### Documentation update

- No documentation update is needed: docs already says it's possible.

### Testing 

NONE

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
